### PR TITLE
Extract access class suffix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 Gemfile.lock
 pkg/*
 *.swp
+/.ruby-gemset
+/.ruby-version

--- a/lib/allowy.rb
+++ b/lib/allowy.rb
@@ -1,3 +1,4 @@
+require 'active_support'
 require 'active_support/core_ext'
 require 'active_support/concern'
 require 'active_support/inflector'

--- a/lib/allowy/registry.rb
+++ b/lib/allowy/registry.rb
@@ -13,22 +13,29 @@ module Allowy
 
     def access_control_for(subject)
       # Try subject as decorated object
-      clazz = class_for "#{subject.class.source_class.name}Access" if subject.class.respond_to?(:source_class)
+      klass = class_for subject.class.source_class.name if subject.class.respond_to?(:source_class)
 
       # Try subject as an object
-      clazz = class_for "#{subject.class.name}Access" unless clazz
+      klass = class_for subject.class.name unless klass
 
       # Try subject as a class
-      clazz = class_for "#{subject.name}Access" if !clazz && subject.is_a?(Class)
+      klass = class_for subject.name if !klass && subject.is_a?(Class)
 
-      return unless clazz # No luck this time
+      return unless klass # No luck this time
       # create a new instance or return existing
-      @registry[clazz] ||= clazz.new(@context)
+      @registry[klass] ||= klass.new(@context)
     end
 
     def class_for(name)
-      name.safe_constantize
+      (name + access_suffix).safe_constantize
     end
 
+    def self.access_suffix
+      "Access"
+    end
+
+    def access_suffix
+      self.class.access_suffix
+    end
   end
 end


### PR DESCRIPTION
- Added `require 'active_support'` to `allowy.rb`. This does not load the entire library, but sets things up for subsequent loading.
- Modified `Registry` so that the suffix used to identify access control classes is specified in a single place, as a class method. Potentially extendable to a class attribute, which would allow configuration of the suffix.