### PR TITLE
registry logic changed to allow namespaced classes to be used for access...

### DIFF
--- a/spec/registry_spec.rb
+++ b/spec/registry_spec.rb
@@ -58,6 +58,26 @@ module Allowy
         subject.access_control_for!(decorated_object).should be_a SampleAccess
       end
 
+      it "should support objects that provide source_class method with namespace or alternative location" do
+        decorator_class = Class.new do
+          def self.source_class
+            Authorisations::AnotherSample
+          end
+        end
+        decorated_object = decorator_class.new
+        subject.access_control_for!(decorated_object).should be_a Authorisations::AnotherSampleAccess
+      end
+
+      it "should support specifying an alternative named access class directly without related base class" do
+        decorator_class = Class.new do
+          def self.source_class
+            Authorisations::AlternativeSampleAccess
+          end
+        end
+        decorated_object = decorator_class.new
+        subject.access_control_for!(decorated_object).should be_a Authorisations::AlternativeSampleAccess
+      end
+
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -37,3 +37,14 @@ end
 class Sample
   attr_accessor :name
 end
+
+module Authorisations
+  class AnotherSample
+  end
+  class AnotherSampleAccess
+    include Allowy::AccessControl
+  end
+  class AlternativeSampleAccess
+    include Allowy::AccessControl
+  end
+end


### PR DESCRIPTION
... rules

also allows specifying an access class directly without a related source class - may need tweaking if it makes things brittle or overreaching
small tweak to class_for method to let the directly specified class work with the designated suffix
added 2 tests and related test classes
